### PR TITLE
Fix unexpected nested array when using a fragment

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function createRoutesFromElements(children, parentPath = []) {
     let treePath = [...parentPath, index];
 
     if (element.type === React.Fragment) {
-      routes.push(createRoutesFromElements(element.props.children, treePath));
+      routes.push(...createRoutesFromElements(element.props.children, treePath));
       return;
     }
 


### PR DESCRIPTION
When using a fragment to group together multiple top-level routes:

<img width="613" alt="image" src="https://github.com/brophdawg11/remix-json-routes/assets/96213/a23b8838-1e4f-411b-8192-424db3245d8b">

The resulting route structure looks like this:

```json
[
  [
    {
      "id": "0-0",
      "index": true,
      "file": "routes/_index.tsx"
    },
    {
      "id": "0-1",
      "path": "users",
      "file": "routes/users.tsx",
      "children": [
        {
          "id": "0-1-0",
          "index": true,
          "file": "routes/users._index.tsx"
        }
      ]
    }
  ]
]
```

and then `@remix-run/dev` throws an error when trying to create a route id for the first entry in the array, which is _also_ an array.

Fix is to push each child of a fragment's children instead of creating a new array with those children.